### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and Push Docker Image
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Headpat-Community/headpat-web/security/code-scanning/10](https://github.com/Headpat-Community/headpat-web/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the workflow does not interact with repository contents in a write capacity (e.g., it does not create releases, modify issues, or update pull requests), the minimal required permission is `contents: read`. This should be added either at the root of the workflow (to apply to all jobs) or to the `build-and-push` job itself. The best practice is to add it at the root level, just below the `name` and before the `on` block, so all jobs inherit the least privilege unless otherwise specified. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
